### PR TITLE
Some small patches and discussion on patching agda-tree to work with forester 5.0 

### DIFF
--- a/src/command/build.rs
+++ b/src/command/build.rs
@@ -121,7 +121,7 @@ fn symbol2forest(working_dir: &PathBuf, elem: &Element) -> String {
             let a_link = split[0];
             let path = Path::new(a_link);
             if working_dir.join("html").join(path).with_extension("tree").exists() {
-                let mut s = path.with_extension("xml").to_str().unwrap().to_owned();
+                let mut s = path.with_extension("").join("index.xml").to_str().unwrap().to_owned();
                 s.push('#');
                 if split.len() == 2 {
                     let id_part = split[1];

--- a/src/command/build.rs
+++ b/src/command/build.rs
@@ -121,7 +121,7 @@ fn symbol2forest(working_dir: &PathBuf, elem: &Element) -> String {
             let a_link = split[0];
             let path = Path::new(a_link);
             if working_dir.join("html").join(path).with_extension("tree").exists() {
-                let mut s = path.with_extension("").join("index.xml#").to_str().unwrap().to_owned();
+                let mut s = path.with_extension("").join("index.xml").to_str().unwrap().to_owned();
                 s.push('#');
                 if split.len() == 2 {
                     let id_part = split[1];

--- a/src/command/build.rs
+++ b/src/command/build.rs
@@ -123,15 +123,22 @@ fn symbol2forest(working_dir: &PathBuf, elem: &Element) -> String {
             if working_dir.join("html").join(path).with_extension("tree").exists() {
                 let mut s = path.with_extension("").join("index.xml").to_str().unwrap().to_owned();
                 s.push('#');
-                s.push('#');
-                s.push('#');
                 if split.len() == 2 {
                     let id_part = split[1];
                     s.push_str(id_part);
                 }
                 s
             } else {
-                value
+                if split.len() == 2 {
+                    let mut s = path.to_str().unwrap().to_owned();
+                    s.push('#');
+                    let id_part = split[1];
+                    s.push_str(id_part);
+                    s
+                }
+                else{
+                    value
+                }
             }
         } else {
             value

--- a/src/command/build.rs
+++ b/src/command/build.rs
@@ -23,7 +23,7 @@ pub fn execute(working_dir: &PathBuf, output_dir: &PathBuf) -> io::Result<()> {
 
         let created_path = output_dir
             .join(tree_path.file_stem().unwrap())
-            .with_extension("tree");
+            .with_added_extension("tree");
         println!("Producing {:?}", created_path);
         let mut out_file = File::create(created_path)?;
         out_file.write_all(new_content.as_bytes())?;
@@ -143,6 +143,8 @@ fn symbol2forest(working_dir: &PathBuf, elem: &Element) -> String {
         // some escape code is useful for HTML, but not for forester
         let childtext = if childtext.contains("&#39;") {
             childtext.replace("&#39;", "'")
+        } else if childtext.starts_with("--") { // TODO: Hack to get \startverb-- to work "properly" in forester
+            childtext.replacen("--", " --", 1)
         } else {
             childtext.to_owned()
         };

--- a/src/command/build.rs
+++ b/src/command/build.rs
@@ -121,7 +121,7 @@ fn symbol2forest(working_dir: &PathBuf, elem: &Element) -> String {
             let a_link = split[0];
             let path = Path::new(a_link);
             if working_dir.join("html").join(path).with_extension("tree").exists() {
-                let mut s = path.with_extension("").join("index.xml").to_str().unwrap().to_owned();
+                let mut s = path.with_extension("").join("index.xml#").to_str().unwrap().to_owned();
                 s.push('#');
                 if split.len() == 2 {
                     let id_part = split[1];

--- a/src/command/build.rs
+++ b/src/command/build.rs
@@ -146,6 +146,11 @@ fn symbol2forest(working_dir: &PathBuf, elem: &Element) -> String {
         } else {
             childtext.to_owned()
         };
+        let childtext = if childtext.contains("&lt;") {
+            childtext.replace("&lt;", "<")
+        } else {
+            childtext.to_owned()
+        };
         // TODO: Hack to get \startverb-- to work "properly" in forester
         let childtext = if childtext.starts_with("--") {
             childtext.replacen("--", " --", 1)

--- a/src/command/build.rs
+++ b/src/command/build.rs
@@ -123,6 +123,8 @@ fn symbol2forest(working_dir: &PathBuf, elem: &Element) -> String {
             if working_dir.join("html").join(path).with_extension("tree").exists() {
                 let mut s = path.with_extension("").join("index.xml").to_str().unwrap().to_owned();
                 s.push('#');
+                s.push('#');
+                s.push('#');
                 if split.len() == 2 {
                     let id_part = split[1];
                     s.push_str(id_part);

--- a/src/command/build.rs
+++ b/src/command/build.rs
@@ -143,9 +143,13 @@ fn symbol2forest(working_dir: &PathBuf, elem: &Element) -> String {
         // some escape code is useful for HTML, but not for forester
         let childtext = if childtext.contains("&#39;") {
             childtext.replace("&#39;", "'")
-        } else if childtext.starts_with("--") { // TODO: Hack to get \startverb-- to work "properly" in forester
-            childtext.replacen("--", " --", 1)
         } else {
+            childtext.to_owned()
+        };
+        // TODO: Hack to get \startverb-- to work "properly" in forester
+        let childtext = if childtext.starts_with("--") {
+            childtext.replacen("--", " --", 1)
+        } else{
             childtext.to_owned()
         };
         if childtext.contains('(')

--- a/src/command/build.rs
+++ b/src/command/build.rs
@@ -150,6 +150,8 @@ fn symbol2forest(working_dir: &PathBuf, elem: &Element) -> String {
             || childtext.contains(')')
             || childtext.contains('{')
             || childtext.contains('}')
+            || childtext.contains('[')
+            || childtext.contains(']')
         {
             s.push_str(format!("{{\\startverb{}\\stopverb}}", childtext).as_str());
         } else {

--- a/src/command/build.rs
+++ b/src/command/build.rs
@@ -169,7 +169,7 @@ fn symbol2forest(working_dir: &PathBuf, elem: &Element) -> String {
             || childtext.contains('[')
             || childtext.contains(']')
         {
-            s.push_str(format!("{{\\startverb{}\\stopverb}}", childtext).as_str());
+            s.push_str(format!("{{\\startverb {}\\stopverb}}", childtext).as_str());
         } else {
             s.push_str(format!("{{{}}}", childtext).as_str());
         }

--- a/src/command/build.rs
+++ b/src/command/build.rs
@@ -169,7 +169,7 @@ fn symbol2forest(working_dir: &PathBuf, elem: &Element) -> String {
             || childtext.contains('[')
             || childtext.contains(']')
         {
-            s.push_str(format!("{{\\startverb{{}}\\stopverb}}", childtext).as_str());
+            s.push_str(format!("{{\\startverb{}\\stopverb}}", childtext).as_str());
         } else {
             s.push_str(format!("{{{}}}", childtext).as_str());
         }

--- a/src/command/build.rs
+++ b/src/command/build.rs
@@ -169,7 +169,7 @@ fn symbol2forest(working_dir: &PathBuf, elem: &Element) -> String {
             || childtext.contains('[')
             || childtext.contains(']')
         {
-            s.push_str(format!("{{\\startverb{}\\stopverb}}", childtext).as_str());
+            s.push_str(format!("{{\\startverb{{}}\\stopverb}}", childtext).as_str());
         } else {
             s.push_str(format!("{{{}}}", childtext).as_str());
         }

--- a/src/command/build.rs
+++ b/src/command/build.rs
@@ -123,15 +123,17 @@ fn symbol2forest(working_dir: &PathBuf, elem: &Element) -> String {
             if working_dir.join("html").join(path).with_extension("tree").exists() {
                 let mut s = path.with_extension("").join("index.xml").to_str().unwrap().to_owned();
                 s.push('#');
+                s.push('#');
                 if split.len() == 2 {
                     let id_part = split[1];
                     s.push_str(id_part);
                 }
                 s
             } else {
+                let mut s = path.to_str().unwrap().to_owned();
+                s.push('#');
+                s.push('#');
                 if split.len() == 2 {
-                    let mut s = path.to_str().unwrap().to_owned();
-                    s.push('#');
                     let id_part = split[1];
                     s.push_str(id_part);
                     s

--- a/src/command/build.rs
+++ b/src/command/build.rs
@@ -151,6 +151,11 @@ fn symbol2forest(working_dir: &PathBuf, elem: &Element) -> String {
         } else {
             childtext.to_owned()
         };
+        let childtext = if childtext.contains("&quot;") {
+            childtext.replace("&quot;", "\"")
+        } else {
+            childtext.to_owned()
+        };
         // TODO: Hack to get \startverb-- to work "properly" in forester
         let childtext = if childtext.starts_with("--") {
             childtext.replacen("--", " --", 1)

--- a/src/command/build.rs
+++ b/src/command/build.rs
@@ -120,7 +120,7 @@ fn symbol2forest(working_dir: &PathBuf, elem: &Element) -> String {
             let split = value.split_terminator('#').collect::<Vec<&str>>();
             let a_link = split[0];
             let path = Path::new(a_link);
-            if working_dir.join(path).with_extension("lagda.tree").exists() {
+            if working_dir.join("html").join(path).with_extension("tree").exists() {
                 let mut s = path.with_extension("xml").to_str().unwrap().to_owned();
                 s.push('#');
                 if split.len() == 2 {

--- a/src/command/build.rs
+++ b/src/command/build.rs
@@ -162,6 +162,11 @@ fn symbol2forest(working_dir: &PathBuf, elem: &Element) -> String {
         } else {
             childtext.to_owned()
         };
+        let childtext = if childtext.contains("&lt;") {
+            childtext.replace("&gt;", ">")
+        } else {
+            childtext.to_owned()
+        };
         let childtext = if childtext.contains("&quot;") {
             childtext.replace("&quot;", "\"")
         } else {


### PR DESCRIPTION
Thanks for making this agda plugin to support literate forester.

I'm working on some (cubical) agda code using agda HEAD (pre-2.9.0) and to get agda-tree working with our code, I patched a couple small things:
- For a module like `A.B.C` in the file `A.B.C.lagda.tree`, `agda --html` (at least as of the current agda HEAD but I believe also since at least 2.8.0) generates the file `html/A.B.C.tree`. When agda-tree goes to write the `tree/*.tree` file, the output should preserve the hierarchical module structure, but as is with `Path::with_extension()`, it seems to just write html/A.tree, which clobbers any other submodule of A
- I often use the Cubical.Data.Sigma $$\Sigma[ x \in A] B x$$ syntax, but the `agda --html` and subsequent agda-tree output often have tags around lone square brackets which forester errors on when parsing, complaining about unmatched brackets. So they also need to be `\startverb`'d
- Relatedly, when an agda single line comment line is parsed, the generated forester code looks like `\startverb--...`, but forester can't parse a dash immediately after a `\startverb` for reasons I don't understand at the moment. I've temporarily added an extra space before the first dash just to get the forest to build, but I haven't come up with a proper fix yet

One thing related to the breaking behavior of forester 5.0:
- Since asset file names are now hashed, agda-tree by default has no idea where to find the `html/*` files to link to. For now, I've just copied html/* into the forester output/ after the forest is built so the links work, but for a proper fix, agda-tree should somehow get the filename translation.